### PR TITLE
Use globbing instead of iterating over `ls`

### DIFF
--- a/elasticsearch/prep-install.origin
+++ b/elasticsearch/prep-install.origin
@@ -1,9 +1,6 @@
 #reconcile upstream to downstream
 es_source=/usr/share/elasticsearch
-for file in $(ls $es_source)
-do
-  mv ${es_source}/${file} ${ES_HOME}
-done
+mv "$es_source"/* "${ES_HOME}"
 
 # list of plugins to be installed
 if [ -z "${ES_CLOUD_K8S_URL:-}" ] ; then


### PR DESCRIPTION
Currently no issue, but iterating over the output of `ls` could be potentially incorrect due to word splitting if any of the expanded paths contain space, newline, etc. Globbing is a recommended approach.

http://mywiki.wooledge.org/BashPitfalls